### PR TITLE
Load if composer dependency

### DIFF
--- a/secupress-backdoor-user.php
+++ b/secupress-backdoor-user.php
@@ -81,7 +81,10 @@ if ( 'secupress-backdoor-user.php' === strtolower( basename( __FILE__ ) ) ) {
 
 // Load WordPress
 while ( ! is_file( 'wp-load.php' ) ) {
-	if ( is_dir( '..' ) && getcwd() != '/' ) {
+	if ( is_dir( 'wp' ) ) {
+		// In case WP is loaded as a Composer dependency
+		chdir( 'wp' );
+	} elseif ( is_dir( '..' ) && getcwd() != '/' ) {
 		chdir( '..' );
 	} else {
 		die( 'Could not find WordPress!' );


### PR DESCRIPTION
Hi @JulioPotier, happy new year! 🎉 

This is MR is about when WordPress is loaded as a Composer dependency, it's located to `wp` folder. It worth force to look for it, even people using composer know what their are doing and backdoor script could be uploaded somewhere else (in the correct folder).

Cheers.